### PR TITLE
Feature/implement nil writer

### DIFF
--- a/log.go
+++ b/log.go
@@ -12,8 +12,16 @@ var (
 	CustomOutput io.Writer
 )
 
+//NilWriter used as custom output writer when CustomOutput nil
+type NilWriter struct{}
+
+func (nw NilWriter) Write(p []byte) (int, error) { return 0, nil }
+
 func init() {
 	Logger = log.New(os.Stdout, "", 0)
+	if CustomOutput == nil {
+		CustomOutput = NilWriter{}
+	}
 }
 
 //NewCustomOutput used to change how Logger send log message

--- a/log_test.go
+++ b/log_test.go
@@ -72,7 +72,7 @@ func TestAlertWithOptional(t *testing.T) {
 //TestAlertWithoutCustomWriter used to make sure that
 //logging still working even without custom io writer implemented
 func TestAlertWithoutCustomWriter(t *testing.T) {
-	Alert(Msg("ini log"))
+	Alert(Msg("without custom writer"))
 	t.Log("logged")
 }
 


### PR DESCRIPTION
**Context**

When `gochill` used as library, there is some bug about `invalid memory address` caused by `io.Writer` refer to empty writer.

I've fixed this issue by auto initialize `CustomOutput` using `NilWriter` when `gochill` called from caller.
